### PR TITLE
Add spymemcached system override properties

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -99,9 +99,9 @@
   <loadproperties srcfile="${ivy.dir}/libraries.properties"/>
   <property name="ivy.jar" location="${lib.dir}/ivy-${ivy.version}.jar"/>
   <property name="ivy_repo_url"
-      value="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar" />
+      value="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar" />
   <property name="mvn_repo_url"
-      value="http://repo2.maven.org/maven2/org/apache/maven/maven-ant-tasks/${mvn.version}/maven-ant-tasks-${mvn.version}.jar"/>
+      value="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/${mvn.version}/maven-ant-tasks-${mvn.version}.jar"/>
   <property name="mvn.jar" location="${build.dir}/maven-ant-tasks-${mvn.version}.jar" />
   <property name="build.ivy.dir" location="${build.dir}/ivy" />
   <property name="build.ivy.lib.dir" location="${build.ivy.dir}/lib" />

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -133,6 +133,13 @@ public class ConnectionFactoryBuilder {
    * wait for space to become available in an output queue.
    */
   public ConnectionFactoryBuilder setOpQueueMaxBlockTime(long t) {
+    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpQueueMaxBlockTimeMs");
+    if (timeoutOverride != null) {
+      try {
+        t = Long.parseLong(timeoutOverride);
+      } catch (NumberFormatException ignored) {
+      }
+    }
     opQueueMaxBlockTime = t;
     return this;
   }
@@ -179,6 +186,14 @@ public class ConnectionFactoryBuilder {
    * Set the default operation timeout in milliseconds.
    */
   public ConnectionFactoryBuilder setOpTimeout(long t) {
+    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpTimeoutMs");
+    if (timeoutOverride != null) {
+      try {
+        t = Long.parseLong(timeoutOverride);
+      } catch (NumberFormatException ignored) {
+      }
+    }
+
     opTimeout = t;
     return this;
   }

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -232,6 +232,14 @@ public class ConnectionFactoryBuilder {
    * Convenience method to specify the protocol to use.
    */
   public ConnectionFactoryBuilder setProtocol(Protocol prot) {
+    String protOverride = System.getProperty("clubhouse.spymemcached.forceProtocol");
+    if (protOverride != null) {
+      if (protOverride.equals("BINARY")) {
+        prot = Protocol.BINARY;
+      } else if (protOverride.equals("TEXT")) {
+        prot = Protocol.TEXT;
+      }
+    }
     switch (prot) {
     case TEXT:
       opFact = new AsciiOperationFactory();

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -39,15 +39,12 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.TapOperation;
 import net.spy.memcached.ops.VBucketAware;
-import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.protocol.binary.MultiGetOperationImpl;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 import net.spy.memcached.util.StringUtils;
-import sun.nio.ch.IOUtil;
 
 import java.io.IOException;
-import java.lang.annotation.Native;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -423,7 +423,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
 
   @Override
   public String toString() {
-    return "Cmd: " + cmd + " Opaque: " + opaque + "ErrorCode:" + errorCode;
+    return "Cmd: " + cmd + " Opaque: " + opaque + " ErrorCode:" + errorCode;
   }
 
   @Override


### PR DESCRIPTION
Adds the following system properties:

* `clubhouse.spymemcached.forceProtocol=TEXT` (or `BINARY`)
* `clubhouse.spymemcached.forceOpTimeoutMs`
* `clubhouse.spymemcached.forceOpQueueMaxBlockTimeMs`

If any of these are set, they will override the value passed to the corresponding builder method in `ConnectionFactoryBuilder`. This is for the very specific purpose of forcing datomic to use the ASCII protocol and messing with timeout settings.

Also has some bitrot-fixing commits to get it building again:

* MemcachedConnection imported some packages from outside the java.base module; fortunately it didn't use them, so I just removed them.
* The ant build referenced a now-gone maven server. URL was updated.