### PR TITLE
Reapply patches on top of aws-elasticache fork

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,103 @@
+# What is this?
+
+This is a fork of the spymemcached java client maintained by Shortcut for use
+in Datomic on-prem peers and transactors.
+
+We maintain a patchset that we apply to whatever spymemcached library Cognitect
+appears to be using in their Datomic releases.
+We then replace their spymemcached jars in the transactor and peers with this one.
+
+Formerly this was https://github.com/couchbase/spymemcached v2.12.3
+and the branch based on that is master+patches-on-couchbase-spymemcached
+and releases tagged like 2.12.3.chX.
+
+But now it appears to be AWS's fork of it that adds ElastiCache auto-discovery
+https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java.
+
+This is currently based on
+https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/releases/tag/1.1.3 
+and our patchset is on branch master+patches-on-aws-elasticache
+and releases tagged like 1.1.3.scX.
+
+
+The patchset includes:
+
+1. A fix for an NPE thrown from fillWriteBuffer. https://github.com/couchbase/spymemcached/pull/38
+2. A fix for incoherent connection state when a Server responds before the client
+   is finished sending: https://github.com/useshortcut/spymemcached/commit/74838cc0a1107676d6224bdee3abad0c03aa848a
+3. Some additional logging to discover and monitor the above two issues:
+   * https://github.com/useshortcut/spymemcached/commit/fb877bf0cd977b32b579515467f6a6dcecb0141b
+   * https://github.com/useshortcut/spymemcached/commit/23c32e641751ae6458560013cefd089b6071a244
+4. Some build.xml changes to get it to build.
+5. The build target (and minimum supported JVM) is Java 11.
+6. Some system properties to override protocol and some timeout values.
+   https://github.com/useshortcut/spymemcached/pull/2
+
+The last item requires explanation.
+We use [McRouter] ([our fork][McRouter-shortcut]) as a memcached proxy
+between Datomic peers and multiple ElastiCache clusters in separate AZs.
+We do this to avoid cross-AZ traffic between the peer and the cluster
+(saving enough money for more clusters!)
+and to provide failover redundancy if a cluster goes down.
+(It's also a flexible platform for more elaborate cache strategies
+or additional tiers, but we haven't done that.)
+
+However McRouter only understands the Memcached text protocol;
+Datomic constructs a memcached client that uses the binary protocol in code
+we do not control.
+The system properties are a hack to let us override Datomic's builder choices
+so we can force use of the text protocol.
+
+This fork adds the following system properties:
+
+  * `shortcut.spymemcached.forceProtocol=TEXT` (or `BINARY`)
+  * `shortcut.spymemcached.forceOpQueueMaxBlockTimeMs`
+    How long to wait for an operation to be enqueued.
+  * `shortcut.spymemcached.forceOpTimeoutMs`
+    How long to wait for an operation to complete.
+    This timer begins when the op is created, so it includes the enqueing time
+    mentioned by the previous property.
+    (We think Datomic may set this timeout to 50.)
+
+[McRouter]: https://github.com/facebook/mcrouter
+[McRouter-shortcut]: https://github.com/useshortcut/mcrouter
+
+## Building for Shortcut
+
+We only use part of the build system: all we need is a jar and to run tests.
+`${version}` is the result of `git describe --abbrev=0`.
+
+1. Build with `ant jar`. This places a file in `build/jars/memcache-asg-java-client-${version}.jar`
+2. Run the integration tests `ant test`
+3. Run the integration tests with a server using the
+   `spymemcached-release-tools.sh` script in the backend repo.
+   This includes a stress test designed to trigger the fillWriteBuffer NPE.
+
+For more thorough building, testing, and deployment docs see the [datomic guide].
+
+[datomic guide]: https://github.com/useshortcut/backend/blob/main/modules/server/resources/datomic/README.md
+
+## Rebasing on upstream changes
+
+1. Rebase, reapply patches, and check for dependency changes.
+2. Determine the new version number. It should be `{upstream-version}.sc1`.
+   Increment sc1 (sc2, etc) only if our build changed but upstream did not.
+3. Bump filename and version of spymemcached pom in root and change
+   dependencies as needed. Commit locally.
+4. Temporarily tag the new version with an annotated git tag,
+   e.g. `git tag 1.1.3.sc1 -m "Shortcut release 1 of AWS memcached 1.1.3"`
+   *Do not push this tag!*
+   The build system uses git tags for versioning.
+5. Then build, test and deploy artifact as above.
+6. Then put the artifact in our local repo, adjust versions, 
+   and test with our applications.
+7. PR your changes to this fork.
+8. After review and merge (merge-commit please!),
+   delete the tag from your local repository, 
+   create the same annotated tag on master, and push it.
+
+**Text below this line is from upstream and kept unchanged.**
+
 # Amazon ElastiCache Cluster Client
 
 [![Build Status](https://travis-ci.org/awslabs/aws-elasticache-cluster-client-memcached-for-java.svg?branch=master)](https://travis-ci.org/awslabs/aws-elasticache-cluster-client-memcached-for-java)

--- a/build.xml
+++ b/build.xml
@@ -341,8 +341,8 @@
         destdir="${build.test.classes}"
         debug="${javac.debug}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath>
         <path refid="test.classpath"/>
       </classpath>
@@ -359,8 +359,8 @@
         destdir="${build.it.classes}"
         debug="${javac.debug}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath>
         <path refid="it.classpath"/>
       </classpath>
@@ -491,8 +491,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath" />
     </javac>
 
@@ -504,8 +504,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath"/>
     </javac>
     <move file="${build.src.dir}/net/spy/memcached/changelog.txt"

--- a/build.xml
+++ b/build.xml
@@ -35,9 +35,9 @@
     </classpath>
   </taskdef>
 
-  <property name="name" value="AmazonElastiCacheClusterClient"/>
+  <property name="name" value="memcache-asg-java-client"/>
   <property name="copyright" value="2006-2011 Dustin Sallings, Matt Ingenthron, 2012-2015 Amazon.com, Inc. or its affiliates" />
-  <property name="group" value="spy" />
+  <property name="group" value="com.datomic" />
 
   <property name="base.src.dir" value="${basedir}/src" />
   <property name="build.dir" value="${basedir}/build" />
@@ -581,7 +581,6 @@
     <!-- prepare for mvn tasks. -->
     <property name="spymemcached.pom" value="${mvn.build.dir}/poms/spymemcached-${version}.pom" />
     <property name="spymemcached-test.pom" value="${mvn.build.dir}/poms/spymemcached-test-${version}.pom" />
-    <property name="spymemcached-it.pom" value="${mvn.build.dir}/poms/spymemcached-it-${version}.pom" />
 
     <!-- Register mvn tasks -->
     <path id="mvn-ant-task.classpath" path="${mvn.jar}" />
@@ -614,18 +613,10 @@
       <dependency group="org.springframework" artifact="spring-beans" version="${spring-beans.version}" optional="true" />
       <dependency group="com.codahale.metrics" artifact="metrics-core" version="${codahale.metrics.version}" />
    </ivy:makepom>
-
-    <ivy:makepom ivyfile="ivy/spymemcached-it.xml"
-        pomfile="${spymemcached-it.pom}"
-        templatefile="ivy/pom.template.xml"
-        settingsRef="${name}.ivy.settings">
-      <mapping conf="default" scope="compile" />
-      <mapping conf="runtime" scope="runtime" />
-      <dependency group="log4j" artifact="log4j" version="${log4j.version}" optional="true" />
-      <dependency group="org.slf4j" artifact="slf4j-api" version="${slf4j.version}" optional="true" />
-      <dependency group="org.springframework" artifact="spring-beans" version="${spring-beans.version}" optional="true" />
-      <dependency group="com.codahale.metrics" artifact="metrics-core" version="${codahale.metrics.version}" />
-   </ivy:makepom>
+<!--    Note (favila): the spymemcached-it.xml file is missing from awslabs upstream,
+        so spymemcached-it.pom is impossible to build.
+        It is only the "integration test" build, though,
+        which we don't need as pom or package to run tests. -->
 
     <!-- Change the version in the pom file to reflect our claimed version. -->
     <replaceregexp>
@@ -642,7 +633,7 @@
     <!-- @todo: change to use ivy publish -->
     <artifact:pom id="spymemcached" file="${spymemcached.pom}" />
     <artifact:install file="${build.dir}/jars/${name}-${version}.jar">
-      <pom refid="${name}" />
+      <pom refid="spymemcached" />
       <attach file="${build.dir}/sources/${name}-${version}.jar"
           classifier="sources" />
       <attach file="${build.dir}/javadocs/${name}-${version}.jar"
@@ -650,18 +641,10 @@
     </artifact:install>
     <artifact:pom id="spymemcached-test" file="${spymemcached-test.pom}" />
       <artifact:install file="${build.dir}/jars/${name}-test-${version}.jar">
-        <pom refid="${name}-test" />
+        <pom refid="spymemcached-test" />
         <attach file="${build.dir}/sources/${name}-test-${version}.jar"
           classifier="sources" />
         <attach file="${build.dir}/javadocs/${name}-test-${version}.jar"
-          classifier="javadoc" />
-    </artifact:install>
-    <artifact:pom id="spymemcached-it" file="${spymemcached-it.pom}" />
-      <artifact:install file="${build.dir}/jars/${name}-it-${version}.jar">
-        <pom refid="${name}-it" />
-        <attach file="${build.dir}/sources/${name}-it-${version}.jar"
-          classifier="sources" />
-        <attach file="${build.dir}/javadocs/${name}-it-${version}.jar"
           classifier="javadoc" />
     </artifact:install>
   </target>
@@ -737,38 +720,6 @@
             <arg value="-DrepositoryId=${maven-staging-repository-id}" />
             <arg value="-DpomFile=${spymemcached-test.pom}" />
             <arg value="-Dfile=${build.dir}/javadocs/${name}-test-${version}.jar" />
-            <arg value="-Dclassifier=javadoc" />
-            <arg value="-Pgpg" />
-    </artifact:mvn>
-
-        <!-- sign and deploy the main artifact -->
-    <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
-            <arg value="-Durl=${maven-staging-repository-url}" />
-            <arg value="-DrepositoryId=${maven-staging-repository-id}" />
-            <arg value="-DpomFile=${spymemcached-it.pom}" />
-            <arg value="-Dfile=${build.dir}/jars/${name}-it-${version}.jar" />
-            <arg value="-Pgpg" />
-    </artifact:mvn>
-
-    <!-- sign and deploy the sources artifact -->
-    <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
-            <arg value="-Durl=${maven-staging-repository-url}" />
-            <arg value="-DrepositoryId=${maven-staging-repository-id}" />
-            <arg value="-DpomFile=${spymemcached-it.pom}" />
-            <arg value="-Dfile=${build.dir}/sources/${name}-it-${version}.jar" />
-            <arg value="-Dclassifier=sources" />
-            <arg value="-Pgpg" />
-    </artifact:mvn>
-
-    <!-- sign and deploy the javadoc artifact -->
-    <artifact:mvn>
-            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
-            <arg value="-Durl=${maven-staging-repository-url}" />
-            <arg value="-DrepositoryId=${maven-staging-repository-id}" />
-            <arg value="-DpomFile=${spymemcached-it.pom}" />
-            <arg value="-Dfile=${build.dir}/javadocs/${name}-it-${version}.jar" />
             <arg value="-Dclassifier=javadoc" />
             <arg value="-Pgpg" />
     </artifact:mvn>
@@ -851,6 +802,9 @@
         <exclude name="LICENSE.txt" />
         <exclude name="README.markdown" />
         <exclude name=".gitreview" />
+        <exclude name=".travis.yml" />
+        <exclude name="NOTICE.txt" />
+        <exclude name="SECURITY.md" />
 	<exclude name=".git/**" />
 	<exclude name=".idea/**" />
 	<exclude name="pom.xml" />

--- a/build.xml
+++ b/build.xml
@@ -805,6 +805,7 @@
         <exclude name=".travis.yml" />
         <exclude name="NOTICE.txt" />
         <exclude name="SECURITY.md" />
+        <exclude name="*.pom" />
 	<exclude name=".git/**" />
 	<exclude name=".idea/**" />
 	<exclude name="pom.xml" />

--- a/memcache-asg-java-client-1.1.3.sc1.pom
+++ b/memcache-asg-java-client-1.1.3.sc1.pom
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <!-- This pom is meant for Shortcut use only in private repositories;
+       do not push it to any public repositories.
+       In particular, note that we *do not* own this groupId!
+       The group and artifact ids match Datomic's just to ease version pinning.
+  -->
+  <groupId>com.datomic</groupId>
+  <artifactId>memcache-asg-java-client</artifactId>
+  <packaging>jar</packaging>
+  <version>1.1.3.sc1</version>
+  <name>Spymemcached</name>
+  <description>Shortcut fork of AWS's fork of Spymemcached Java client</description>
+  <url>http://www.couchbase.org/code/couchbase/java</url>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+    
+  <scm>
+    <url>https://github.com/useshortcut/spymemcached</url>
+    <connection>scm:git:git://github.com/useshortcut/spymemcached.git</connection>
+  </scm>
+
+  <developers>
+    <developer>
+      <id>net.spy.spymemcached</id>
+      <name>The Spymemcached Project Contributors</name>
+      <url>https://code.google.com/p/spymemcached/</url>
+      <organization>Couchbase, Inc.</organization>
+      <organizationUrl>http://couchbase.com/</organizationUrl>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.16</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.5</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-ec2</artifactId>
+      <!-- Using 1.12.x series to use Jackson 2.12.x and avoid version fights. -->
+      <version>1.12.156</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>3.0.3.RELEASE</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.0.1</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -251,6 +251,14 @@ public class ConnectionFactoryBuilder {
    * Convenience method to specify the protocol to use.
    */
   public ConnectionFactoryBuilder setProtocol(Protocol prot) {
+    String protOverride = System.getProperty("clubhouse.spymemcached.forceProtocol");
+    if (protOverride != null) {
+      if (protOverride.equals("BINARY")) {
+        prot = Protocol.BINARY;
+      } else if (protOverride.equals("TEXT")) {
+        prot = Protocol.TEXT;
+      }
+    }
     switch (prot) {
     case TEXT:
       opFact = new AsciiOperationFactory();

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -152,7 +152,7 @@ public class ConnectionFactoryBuilder {
    * wait for space to become available in an output queue.
    */
   public ConnectionFactoryBuilder setOpQueueMaxBlockTime(long t) {
-    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpQueueMaxBlockTimeMs");
+    String timeoutOverride = System.getProperty("shortcut.spymemcached.forceOpQueueMaxBlockTimeMs");
     if (timeoutOverride != null) {
       try {
         t = Long.parseLong(timeoutOverride);
@@ -205,7 +205,7 @@ public class ConnectionFactoryBuilder {
    * Set the default operation timeout in milliseconds.
    */
   public ConnectionFactoryBuilder setOpTimeout(long t) {
-    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpTimeoutMs");
+    String timeoutOverride = System.getProperty("shortcut.spymemcached.forceOpTimeoutMs");
     if (timeoutOverride != null) {
       try {
         t = Long.parseLong(timeoutOverride);
@@ -266,7 +266,7 @@ public class ConnectionFactoryBuilder {
    * Convenience method to specify the protocol to use.
    */
   public ConnectionFactoryBuilder setProtocol(Protocol prot) {
-    String protOverride = System.getProperty("clubhouse.spymemcached.forceProtocol");
+    String protOverride = System.getProperty("shortcut.spymemcached.forceProtocol");
     if (protOverride != null) {
       if (protOverride.equals("BINARY")) {
         prot = Protocol.BINARY;

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -152,6 +152,13 @@ public class ConnectionFactoryBuilder {
    * wait for space to become available in an output queue.
    */
   public ConnectionFactoryBuilder setOpQueueMaxBlockTime(long t) {
+    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpQueueMaxBlockTimeMs");
+    if (timeoutOverride != null) {
+      try {
+        t = Long.parseLong(timeoutOverride);
+      } catch (NumberFormatException ignored) {
+      }
+    }
     opQueueMaxBlockTime = t;
     return this;
   }
@@ -198,6 +205,14 @@ public class ConnectionFactoryBuilder {
    * Set the default operation timeout in milliseconds.
    */
   public ConnectionFactoryBuilder setOpTimeout(long t) {
+    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpTimeoutMs");
+    if (timeoutOverride != null) {
+      try {
+        t = Long.parseLong(timeoutOverride);
+      } catch (NumberFormatException ignored) {
+      }
+    }
+
     opTimeout = t;
     return this;
   }

--- a/src/main/java/net/spy/memcached/FillWriteBufferStatus.java
+++ b/src/main/java/net/spy/memcached/FillWriteBufferStatus.java
@@ -1,0 +1,77 @@
+/**
+ * (c) Copyright 2019 freiheit.com technologies GmbH
+ *
+ * Created on 2019-09-26 by Marco Kortkamp (marco.kortkamp@freiheit.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached;
+
+import net.spy.memcached.ops.OperationState;
+
+/**
+ * Status, which tells if a fillWriteBuffer method has
+ * successfully been completed or not.
+ *
+ * @author Marco Kortkamp (marco.kortkamp@freiheit.com)
+ */
+public enum FillWriteBufferStatus {
+    SUCCESS,
+    /**
+     * An operation may be marked as canceled (by an async callback),
+     * before a fillWriteBuffer completed successfully.
+     * <p>
+     * This has been observed, if a large values are written in
+     * a very high frequency to the memcached and the payload contains
+     * the error-code ERR_2BIG.
+     * <p>
+     * @see <a href="https://github.com/couchbase/spymemcached/pull/17/commits/d29fea258f6595922b19667efd39a41611d0c0ec">Bug-Report</a>
+     */
+    OP_STATUS_IS_COMPLETED,
+    /**
+     * The residual entries are just for paranoia. If the operation
+     * state can switch to completed, it might switch to another state
+     * as well. Although this has not been observed jet TBMK.
+     */
+    OP_STATUS_IS_WRITE_QUEUED,
+    OP_STATUS_IS_READING,
+    OP_STATUS_IS_RETRY
+    ;
+
+    public static FillWriteBufferStatus forOperationState(final OperationState opState) {
+        switch (opState){
+            case WRITE_QUEUED:
+                return OP_STATUS_IS_WRITE_QUEUED;
+            case WRITING:
+                return SUCCESS;
+            case READING:
+                return OP_STATUS_IS_READING;
+            case COMPLETE:
+                return OP_STATUS_IS_COMPLETED;
+            case RETRY:
+                return OP_STATUS_IS_RETRY;
+        }
+        return null;
+    }
+
+    public boolean isSuccess() {
+        return this == SUCCESS;
+    }
+}

--- a/src/main/java/net/spy/memcached/FillWriteBufferStatus.java
+++ b/src/main/java/net/spy/memcached/FillWriteBufferStatus.java
@@ -52,7 +52,11 @@ public enum FillWriteBufferStatus {
      */
     OP_STATUS_IS_WRITE_QUEUED,
     OP_STATUS_IS_READING,
-    OP_STATUS_IS_RETRY
+    OP_STATUS_IS_RETRY,
+    /**
+     * The server completed a write operation but the
+     */
+    OP_STATUS_IS_INTERRUPTED_BY_COMPLETION
     ;
 
     public static FillWriteBufferStatus forOperationState(final OperationState opState) {
@@ -73,5 +77,8 @@ public enum FillWriteBufferStatus {
 
     public boolean isSuccess() {
         return this == SUCCESS;
+    }
+    public boolean needsReconnect() {
+        return this == OP_STATUS_IS_INTERRUPTED_BY_COMPLETION;
     }
 }

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -998,12 +998,18 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
    */
   private void handleWrites(final MemcachedNode node) throws IOException {
     FillWriteBufferStatus bufferFilledStatus = node.fillWriteBuffer(shouldOptimize);
+    if (bufferFilledStatus.needsReconnect()) {
+      throw new IOException("Reconnecting because write was interrupted by completion");
+    }
     boolean canWriteMore = node.getBytesRemainingToWrite() > 0;
     while (canWriteMore && bufferFilledStatus.isSuccess()) {
       int wrote = node.writeSome();
       metrics.updateHistogram(OVERALL_AVG_BYTES_WRITE_METRIC, wrote);
       bufferFilledStatus = node.fillWriteBuffer(shouldOptimize);
       canWriteMore = wrote > 0 && node.getBytesRemainingToWrite() > 0;
+    }
+    if (bufferFilledStatus.needsReconnect()) {
+      throw new IOException("Reconnecting because write was interrupted by completion");
     }
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -44,15 +44,12 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.TapOperation;
 import net.spy.memcached.ops.VBucketAware;
-import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.protocol.binary.MultiGetOperationImpl;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 import net.spy.memcached.util.StringUtils;
-import sun.nio.ch.IOUtil;
 
 import java.io.IOException;
-import java.lang.annotation.Native;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -44,12 +44,15 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.TapOperation;
 import net.spy.memcached.ops.VBucketAware;
+import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.protocol.binary.MultiGetOperationImpl;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 import net.spy.memcached.util.StringUtils;
+import sun.nio.ch.IOUtil;
 
 import java.io.IOException;
+import java.lang.annotation.Native;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -994,12 +997,12 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
    * @throws IOException can be raised during writing failures.
    */
   private void handleWrites(final MemcachedNode node) throws IOException {
-    node.fillWriteBuffer(shouldOptimize);
+    FillWriteBufferStatus bufferFilledStatus = node.fillWriteBuffer(shouldOptimize);
     boolean canWriteMore = node.getBytesRemainingToWrite() > 0;
-    while (canWriteMore) {
+    while (canWriteMore && bufferFilledStatus.isSuccess()) {
       int wrote = node.writeSome();
       metrics.updateHistogram(OVERALL_AVG_BYTES_WRITE_METRIC, wrote);
-      node.fillWriteBuffer(shouldOptimize);
+      bufferFilledStatus = node.fillWriteBuffer(shouldOptimize);
       canWriteMore = wrote > 0 && node.getBytesRemainingToWrite() > 0;
     }
   }
@@ -1687,23 +1690,30 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
     while (running) {
       try {
         handleIO();
-      } catch (IOException e) {
+      } catch (final IOException e) {
         logRunException(e);
-      } catch (CancelledKeyException e) {
+      } catch (final CancelledKeyException e) {
         logRunException(e);
-      } catch (ClosedSelectorException e) {
+      } catch (final ClosedSelectorException e) {
         logRunException(e);
-      } catch (IllegalStateException e) {
+      } catch (final IllegalStateException e) {
         logRunException(e);
-      } catch (ConcurrentModificationException e) {
+      } catch (final ConcurrentModificationException e) {
         logRunException(e);
+      } catch (final NullPointerException e) {
+        logRunException(e);
+      } catch (final Exception e) {
+        // Exception, because we don't want to catch an OutOfMemoryError here.
+        logException(e);
       }
     }
     getLogger().info("Shut down memcached client");
   }
 
+
+
   /**
-   * Log a exception to different levels depending on the state.
+   * Log an exception to different levels depending on the state.
    *
    * Exceptions get logged at debug level when happening during shutdown, but
    * at warning level when operating normally.
@@ -1715,6 +1725,19 @@ public class MemcachedConnection extends SpyThread implements ClusterConfigurati
       getLogger().debug("Exception occurred during shutdown", e);
     } else {
       getLogger().warn("Problem handling memcached IO", e);
+    }
+  }
+
+  /**
+   * Logs an exception to different levels depending on the state.
+   *
+   * @param e the Throwable to log.
+   */
+  private void logException(final Exception e) {
+    if (shutDown) {
+      getLogger().warn("Exception occurred during shutdown", e);
+    } else {
+      getLogger().error("Unexpected problem handling memcached IO", e);
     }
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -64,17 +64,18 @@ public interface MemcachedNode {
   void setupResend();
 
   /**
+   * Transition the current write item into a read state.
+   */
+  void transitionWriteItem();
+
+  /**
    * Fill the write buffer with data from the next operations in the queue.
    *
    * @param optimizeGets if true, combine sequential gets into a single
    *          multi-key get
+   * @return FillWriteBufferStatus indicates, whether this method was completed successfully or not.
    */
-  void fillWriteBuffer(boolean optimizeGets);
-
-  /**
-   * Transition the current write item into a read state.
-   */
-  void transitionWriteItem();
+  FillWriteBufferStatus fillWriteBuffer(boolean optimizeGets);
 
   /**
    * Get the operation at the top of the queue that is requiring input.

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -68,7 +68,7 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public void fillWriteBuffer(boolean optimizeGets) {
+  public FillWriteBufferStatus fillWriteBuffer(boolean optimizeGets) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -254,8 +254,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   private FillWriteBufferStatus logCleanUpAndReturnStatus(
           final FillWriteBufferStatus status, final Operation op,
           final ByteBuffer obuf) {
-    if (getLogger().isDebugEnabled()) {
-      getLogger().debug("fillWriteBuffer not finished successfully."
+    if (getLogger().isInfoEnabled()) {
+      getLogger().info("fillWriteBuffer not finished successfully."
               + " FillWriteBufferStatus: " + status
               + " ByteBuffer: " + obuf
               + " Operation: " + op

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -208,8 +208,17 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
           final OperationState oState = o.getState();
           ByteBuffer obuf = o.getBuffer();
           // This cases may happen due to race condition. See FillWriteBufferNPETest.
+          // If we received a response to an operation before we finished sending
+          // the full payload we can no longer trust that the server and client
+          // are synchronized. For example, we may be in the middle of sending
+          // bytes of a declared length and not sent all the bytes yet,
+          // so the server may interpret the next op as part of the payload
+          // of the previous op.
+          // The only safe thing to do is abandon the current write op and
+          // close and reestablish the connection.
           if (oState != OperationState.WRITING || obuf == null) {
-            return logCleanUpAndReturnStatus(FillWriteBufferStatus.forOperationState(oState), o, obuf);
+            logCleanUpAndReturnStatus(FillWriteBufferStatus.forOperationState(oState), o, obuf);
+            return FillWriteBufferStatus.OP_STATUS_IS_INTERRUPTED_BY_COMPLETION;
           }
 
           int bytesToCopy = Math.min(getWbuf().remaining(), obuf.remaining());

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -40,10 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import net.spy.memcached.ConnectionFactory;
-import net.spy.memcached.FailureMode;
-import net.spy.memcached.MemcachedConnection;
-import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.*;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.config.NodeEndPoint;
 import net.spy.memcached.ops.Operation;
@@ -201,23 +198,26 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    *
    * @see net.spy.memcached.MemcachedNode#fillWriteBuffer(boolean)
    */
-  public final void fillWriteBuffer(boolean shouldOptimize) {
+  public final FillWriteBufferStatus fillWriteBuffer(boolean shouldOptimize) {
     if (toWrite == 0 && readQ.remainingCapacity() > 0) {
       getWbuf().clear();
       Operation o=getNextWritableOp();
 
       while(o != null && toWrite < getWbuf().capacity()) {
         synchronized(o) {
-          assert o.getState() == OperationState.WRITING;
-
+          final OperationState oState = o.getState();
           ByteBuffer obuf = o.getBuffer();
-          assert obuf != null : "Didn't get a write buffer from " + o;
+          // This cases may happen due to race condition. See FillWriteBufferNPETest.
+          if (oState != OperationState.WRITING || obuf == null) {
+            return logCleanUpAndReturnStatus(FillWriteBufferStatus.forOperationState(oState), o, obuf);
+          }
+
           int bytesToCopy = Math.min(getWbuf().remaining(), obuf.remaining());
           byte[] b = new byte[bytesToCopy];
           obuf.get(b);
           getWbuf().put(b);
           getLogger().debug("After copying stuff from %s: %s", o, getWbuf());
-          if (!o.getBuffer().hasRemaining()) {
+          if (!obuf.hasRemaining()) {
             o.writeComplete();
             transitionWriteItem();
 
@@ -239,8 +239,23 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     } else {
       getLogger().debug("Buffer is full, skipping");
     }
+    return FillWriteBufferStatus.SUCCESS;
   }
 
+  private FillWriteBufferStatus logCleanUpAndReturnStatus(
+          final FillWriteBufferStatus status, final Operation op,
+          final ByteBuffer obuf) {
+    if (getLogger().isDebugEnabled()) {
+      getLogger().debug("fillWriteBuffer not finished successfully."
+              + " FillWriteBufferStatus: " + status
+              + " ByteBuffer: " + obuf
+              + " Operation: " + op
+              + ". Removing operation.");
+    }
+    wbuf.clear();
+    removeCurrentWriteOp();
+    return status;
+  }
 
   private Operation getNextWritableOp() {
     Operation o = getCurrentWriteOp();
@@ -512,8 +527,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   @Override
   public final String toString() {
     int sops = 0;
-    if (getSk() != null && getSk().isValid()) {
-      sops = getSk().interestOps();
+    final SelectionKey sk = getSk();
+    if (sk != null && sk.isValid()) {
+      sops = sk.interestOps();
     }
     int rsize = readQ.size() + (optimizedOp == null ? 0 : 1);
     int wsize = writeQ.size();

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -423,7 +423,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
 
   @Override
   public String toString() {
-    return "Cmd: " + cmd + " Opaque: " + opaque + "ErrorCode:" + errorCode;
+    return "Cmd: " + cmd + " Opaque: " + opaque + " ErrorCode:" + errorCode;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -423,7 +423,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
 
   @Override
   public String toString() {
-    return "Cmd: " + cmd + " Opaque: " + opaque;
+    return "Cmd: " + cmd + " Opaque: " + opaque + "ErrorCode:" + errorCode;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -209,9 +209,16 @@ public  abstract class OperationImpl extends BaseOperationImpl
         && !getState().equals(OperationState.COMPLETE)) {
       transitionState(OperationState.RETRY);
     } else {
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      setOpStateAndTriggerCallback(status, errorCode);
     }
+  }
+
+  private void setOpStateAndTriggerCallback(final OperationStatus status, final int errorCode) {
+    if (getLogger().isTraceEnabled()) {
+      getLogger().trace("Received error-code: " + errorCode);
+    }
+    transitionState(OperationState.COMPLETE);
+    getCallback().receivedStatus(status);
   }
 
   /**

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -98,8 +98,8 @@ public class MockMemcachedNode implements MemcachedNode {
     // noop
   }
 
-  public void fillWriteBuffer(boolean optimizeGets) {
-    // noop
+  public FillWriteBufferStatus fillWriteBuffer(boolean optimizeGets) {
+    return null;
   }
 
   public void transitionWriteItem() {

--- a/src/test/manual/net/spy/memcached/test/FillWriteBufferNPETest.java
+++ b/src/test/manual/net/spy/memcached/test/FillWriteBufferNPETest.java
@@ -1,0 +1,87 @@
+/**
+ * (c) Copyright 2019 freiheit.com technologies GmbH
+ *
+ * Created on 2019-09-25 by Marco Kortkamp (marco.kortkamp@freiheit.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached.test;
+
+import net.spy.memcached.BinaryConnectionFactory;
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+
+/**
+ * A manual test which tries to trigger a NPE in the fillWriteBuffer
+ * method, when large session passed to the memcached with very high
+ * frequency.
+ *
+ * The initial verison of this test was provided in the following bug report.
+ * @see <a href="https://github.com/couchbase/spymemcached/pull/17/commits/d29fea258f6595922b19667efd39a41611d0c0ec">Bug Report</a>
+ *
+ * @author Marco Kortkamp (marco.kortkamp@freiheit.com)
+ */
+public class FillWriteBufferNPETest {
+    private static final String MEMCACHED_HOST = "localhost";
+    private static final int MEMCACHED_PORT = 11211;
+    private static final int SLEEP_MS = 1;
+
+    /**
+     * In order to run this test you need a memcached instance.
+     * It can e.g. be started by:
+     *     $ memcached -d -p 11211 -u memcached -m 64 -c 1024
+     *
+     * Experiments were conducted with the VM-Options "-Xmx4G".
+     */
+    public static void main(final String[] args) throws IOException, InterruptedException {
+        final MemcachedClient client = new MemcachedClient(new BinaryConnectionFactory(),
+                Collections.singletonList(new InetSocketAddress(MEMCACHED_HOST, MEMCACHED_PORT))
+        );
+
+        final SerializingTranscoder transcoder  = new SerializingTranscoder();
+        transcoder.setCompressionThreshold(Integer.MAX_VALUE);
+
+        final byte[] data = new byte[2 * 1024 * 1024];
+        int i = 0;
+        try {
+            while (true) {
+                client.set("test", 60, data, transcoder);
+                /*
+                 * If this sleep is not in, the memcached ocassionally closes
+                 * the socket with "java.io.IOException: Connection reset by peer"
+                 * and during the reconnect phase the while loop shovels us into
+                 * a an "java.lang.OutOfMemoryError: Java heap space".
+                 * I'm not sure if this is a remaining issue.
+                 */
+                Thread.sleep(SLEEP_MS);
+                if (i > 0 && i % 100 == 0) {
+                    System.out.println(i);
+                }
+                i++;
+            }
+        } catch (final Throwable t) {
+            t.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This is all the patches we applied over the couchbase repo re-applied over the awslabs fork tag v1.1.3 instead.

Adds a bit to the top of the README explaining what this is.
