### PR TITLE
New release of spymemcached based on couchbase fork

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,118 @@
+# What is this?
+
+This is a fork of the spymemcached java client maintained by Shortcut for use
+in Datomic on-prem peers and transactors.
+
+We maintain a patchset that we apply to the spymemcached library.
+We then replace their spymemcached jars in the transactor and peers with this one.
+
+Datomic <= 1.0.6316 used https://github.com/couchbase/spymemcached v2.12.3
+and the branch based on that is master+patches-on-couchbase-spymemcached
+and releases tagged like 2.12.3.chX or 2.12.3.scX.
+
+Datomic now appears to use AWS's fork of it that adds ElastiCache auto-discovery
+https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java.
+
+We have a patchset for that on master+patches-on-aws-elasticache
+*but it is not functional*.
+It is based on
+https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/releases/tag/1.1.3
+and our patchset is on branch
+and releases tagged like 1.1.3.scX.
+
+Cognitect appears to have added to their fork at least an additional configurable
+timeout value for the ElastiCache-specific "config get <cluster>" command,
+and without those patches this release will not work with Datomic.
+
+However, Datomic appears to have some reflection in place to determine if the
+spymemcached client lib supports AWS discovery.
+So if we use a different spymemcached library *not* based on the AWS fork,
+memcached caching with Datomic still works but doesn't support auto-discovery.
+
+This is fine for us, because we don't need this: we proxy through McRouter.
+The thing we need is overriding the protocol format to TEXT.
+(More on this later.)
+
+[auto-node-discovery]: https://docs.datomic.com/on-prem/overview/caching.html#node-auto-discovery
+
+
+The patchset includes:
+
+1. A fix for an NPE thrown from fillWriteBuffer. https://github.com/couchbase/spymemcached/pull/38
+2. A fix for incoherent connection state when a Server responds before the client
+   is finished sending: https://github.com/useshortcut/spymemcached/commit/74838cc0a1107676d6224bdee3abad0c03aa848a
+3. Some additional logging to discover and monitor the above two issues:
+    * https://github.com/useshortcut/spymemcached/commit/fb877bf0cd977b32b579515467f6a6dcecb0141b
+    * https://github.com/useshortcut/spymemcached/commit/23c32e641751ae6458560013cefd089b6071a244
+4. Some minor build.xml bitrot cleanup, changelog suppression, and targets Java 11.
+5. Some system properties to override protocol and some timeout values.
+   https://github.com/useshortcut/spymemcached/pull/2
+
+The last item requires explanation.
+We use [McRouter] ([our fork][McRouter-shortcut]) as a memcached proxy
+between Datomic peers and multiple ElastiCache clusters in separate AZs.
+We do this to avoid cross-AZ traffic between the peer and the cluster
+(saving enough money for more clusters!)
+and to provide failover redundancy if a cluster goes down.
+(It's also a flexible platform for more elaborate cache strategies
+or additional tiers, but we haven't done that.)
+
+However, McRouter only understands the Memcached text protocol;
+Datomic constructs a memcached client that uses the binary protocol in code
+we do not control.
+The system properties are a hack to let us override Datomic's builder choices
+so we can force use of the text protocol.
+
+This fork adds the following system properties:
+
+* `shortcut.spymemcached.forceProtocol=TEXT` (or `BINARY`)
+* `shortcut.spymemcached.forceOpQueueMaxBlockTimeMs`
+  How long to wait for an operation to be enqueued.
+* `shortcut.spymemcached.forceOpTimeoutMs`
+  How long to wait for an operation to complete.
+  This timer begins when the op is created, so it includes the enqueing time
+  mentioned by the previous property.
+  (We think Datomic may set this timeout to 50.)
+
+[McRouter]: https://github.com/facebook/mcrouter
+[McRouter-shortcut]: https://github.com/useshortcut/mcrouter
+
+## Building for Shortcut
+
+We only use part of the build system: all we need is a jar and to run tests.
+`${version}` is the result of `git describe --abbrev=0`.
+
+1. Build with `ant jar`. This places a file in `build/jars/spymemcached-${version}.jar`
+2. Run the integration tests `ant test`
+3. Run the integration tests with a server using the
+   `spymemcached-release-tools.sh` script in the backend repo.
+   This includes a stress test designed to trigger the fillWriteBuffer NPE.
+
+For more thorough building, testing, and deployment docs see the [datomic guide].
+
+[datomic guide]: https://github.com/useshortcut/backend/blob/main/modules/server/resources/datomic/README.md
+
+## Rebasing on upstream changes
+
+1. Rebase, reapply patches, and check for dependency changes.
+2. Determine the new version number. It should be `{upstream-version}.sc1`.
+   Increment sc1 (sc2, etc) only if our build changed but upstream did not.
+3. Bump filename and version of spymemcached pom in root and change
+   dependencies as needed. Commit locally.
+4. Temporarily tag the new version with an annotated git tag,
+   e.g. `git tag 2.12.3.sc5 -m "Shortcut release 5 of Couchbase memcached 2.12.3"`
+   *Do not push this tag!*
+   The build system uses git tags for versioning.
+5. Then build, test and deploy artifact as above.
+6. Then put the artifact in our local repo, adjust versions,
+   and test with our applications.
+7. PR your changes to this fork.
+8. After review and merge (merge-commit please!),
+   delete the tag from your local repository,
+   create the same annotated tag on master, and push it.
+
+**Text below this line is from upstream and kept unchanged.**
+
 # Building
 
 Spymemcached can be compiled using Apache Ant by running the following

--- a/build.xml
+++ b/build.xml
@@ -708,6 +708,7 @@
         <exclude name="LICENSE.txt" />
         <exclude name="README.markdown" />
         <exclude name=".gitreview" />
+        <exclude name="*.pom" />
 	<exclude name=".git/**" />
 	<exclude name=".idea/**" />
 	<exclude name="pom.xml" />

--- a/build.xml
+++ b/build.xml
@@ -291,8 +291,8 @@
         destdir="${build.test.classes}"
         debug="${javac.debug}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath>
         <path refid="test.classpath"/>
       </classpath>
@@ -401,8 +401,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath" />
     </javac>
 
@@ -414,8 +414,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath"/>
     </javac>
     <move file="${build.src.dir}/net/spy/memcached/changelog.txt"

--- a/build.xml
+++ b/build.xml
@@ -418,8 +418,14 @@
         source="11">
       <classpath refid="${name}.common.classpath"/>
     </javac>
+    <!--
+    This adds a changelog to the jar that you can read with
+    `java -jar the-jar.jar -c`
+    But this adds hundreds of kb and leaks information, so we comment it out.
+
     <move file="${build.src.dir}/net/spy/memcached/changelog.txt"
         tofile="${build.classes}/net/spy/memcached/changelog.txt" />
+    -->
   </target>
 
   <target name="srcjar" depends="init,jar"

--- a/spymemcached-2.12.3.sc5.pom
+++ b/spymemcached-2.12.3.sc5.pom
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <!-- This pom is meant for Shortcut use only in private repositories;
+       do not push it to any public repositories.
+       In particular, note that we *do not* own this groupId!
+       The group and artifact ids match Datomic's just to ease version pinning.
+  -->
+  <groupId>com.datomic</groupId>
+  <artifactId>memcache-asg-java-client</artifactId>
+  <packaging>jar</packaging>
+  <version>2.12.3.sc5</version>
+  <name>Spymemcached</name>
+  <description>Shortcut fork of Spymemcached Java client for Datomic >= 1.0.6316</description>
+  <url>https://github.com/useshortcut/spymemcached</url>
+  <scm>
+    <tag>2.12.3.sc5</tag>
+    <url>https://github.com/useshortcut/spymemcached/tree/${project.scm.tag}</url>
+    <connection>scm:git:https://github.com/useshortcut/spymemcached.git</connection>
+    <developerConnection>scm:git:git@github.com:useshortcut/spymemcached.git</developerConnection>
+  </scm>
+</project>

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -133,7 +133,7 @@ public class ConnectionFactoryBuilder {
    * wait for space to become available in an output queue.
    */
   public ConnectionFactoryBuilder setOpQueueMaxBlockTime(long t) {
-    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpQueueMaxBlockTimeMs");
+    String timeoutOverride = System.getProperty("shortcut.spymemcached.forceOpQueueMaxBlockTimeMs");
     if (timeoutOverride != null) {
       try {
         t = Long.parseLong(timeoutOverride);
@@ -186,7 +186,7 @@ public class ConnectionFactoryBuilder {
    * Set the default operation timeout in milliseconds.
    */
   public ConnectionFactoryBuilder setOpTimeout(long t) {
-    String timeoutOverride = System.getProperty("clubhouse.spymemcached.forceOpTimeoutMs");
+    String timeoutOverride = System.getProperty("shortcut.spymemcached.forceOpTimeoutMs");
     if (timeoutOverride != null) {
       try {
         t = Long.parseLong(timeoutOverride);
@@ -247,7 +247,7 @@ public class ConnectionFactoryBuilder {
    * Convenience method to specify the protocol to use.
    */
   public ConnectionFactoryBuilder setProtocol(Protocol prot) {
-    String protOverride = System.getProperty("clubhouse.spymemcached.forceProtocol");
+    String protOverride = System.getProperty("shortcut.spymemcached.forceProtocol");
     if (protOverride != null) {
       if (protOverride.equals("BINARY")) {
         prot = Protocol.BINARY;

--- a/src/scripts/write-version-info.sh
+++ b/src/scripts/write-version-info.sh
@@ -97,33 +97,7 @@ public final class BuildInfo extends Properties {
 
   public static void main(String args[]) throws Exception {
     BuildInfo bi=new BuildInfo();
-    String cl="%" + "CHANGELOG" + "%";
-
     System.out.println(bi);
-
-    // If there was a changelog, let it be shown.
-    if(!cl.equals("net/spy/memcached/changelog.txt")) {
-      if(args.length > 0 && args[0].equals("-c")) {
-        System.out.println(" -- Changelog:\n");
-
-        URL u=bi.getFile("net/spy/memcached/changelog.txt");
-        InputStream is=u.openStream();
-        try {
-          byte data[]=new byte[8192];
-          int bread=0;
-          do {
-            bread=is.read(data);
-            if(bread > 0) {
-              System.out.write(data, 0, bread);
-            }
-          } while(bread != -1);
-        } finally {
-          is.close();
-        }
-      } else {
-        System.out.println("(add -c to see the recent changelog)");
-      }
-    }
   }
 }
 EOF


### PR DESCRIPTION
This is like #3 , but is *not* rebased on top of AWS's fork.

Cognitect appears to have added to their fork at least an additional configurable
timeout value for the ElastiCache-specific `config get <cluster>` command,
and without those patches this release will not work with Datomic.

However, Datomic appears to have some reflection in place to determine if the
spymemcached client lib supports AWS discovery.
So if we use a different spymemcached library *not* based on the AWS fork,
memcached caching with Datomic still works but doesn't support auto-discovery.

Changes:

* Rename clubhouse to shortcut (cherry picked from commit 4868ad74a31f3a9b1521defe8e32d4749079e89e)
* Build targets Java 11
* Don't write changelog into jar
* Add pom for use with datomic
* Update README so future selves know what this is (based on changes in #3)
